### PR TITLE
clarify purpose of rdx in hello world example

### DIFF
--- a/code/x86-intel/hello-world/hello-world-linux.asm
+++ b/code/x86-intel/hello-world/hello-world-linux.asm
@@ -60,7 +60,7 @@ _start:
     mov     rax, 1          ; system call for write. **linux specific** 
     mov     rdi, 1          ; Set output to stdout. 1 = stdout, which is normally connected to the terminal.
     mov     rsi, msg        ; address of string to output
-    mov     rdx, msg.len    ; rdx holds address of next byte to write. msg.len is the number of bytes to write
+    mov     rdx, msg.len    ; rdx holds the number of bytes to write. msg.len is the length of msg
     syscall                 ; invoke operating system to do the write
 
     mov     rax, 60         ; system call for exit. anything with 0x2 is mac specific

--- a/code/x86-intel/hello-world/hello-world-mac.asm
+++ b/code/x86-intel/hello-world/hello-world-mac.asm
@@ -57,7 +57,7 @@ _main:
     mov     rax, 0x2000004  ; system call for write. anything with 0x2 is mac specific
     mov     rdi, 1          ; Set output to stdout. 1 = stdout, which is normally connected to the terminal.
     mov     rsi, msg        ; address of string to output
-    mov     rdx, msg.len    ; rdx holds address of next byte to write. msg.len is the number of bytes to write
+    mov     rdx, msg.len    ; rdx holds the number of bytes to write. msg.len is the length of msg
     syscall                 ; invoke operating system to do the write
 
     mov     rax, 0x2000001  ; system call for exit. anything with 0x2 is mac specific


### PR DESCRIPTION
Clarify rdx -- it holds a count of bytes to write rather than an address. From https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#x86_64-64_bit :
```
size_t count
```