### PR TITLE
Fixed issue in hello-world-mac.asm based on yasm error

### DIFF
--- a/code/x86-intel/hello-world/hello-world-mac.asm
+++ b/code/x86-intel/hello-world/hello-world-mac.asm
@@ -57,7 +57,7 @@ _main:
     mov     rax, 0x2000004  ; system call for write. anything with 0x2 is mac specific
     mov     rdi, 1          ; Set output to stdout. 1 = stdout, which is normally connected to the terminal.
     mov     rsi, qword msg  ; Save the value of msg into rsi. qword is specifying how much data we want to retrieve.
-                                           ; Since x86-64 is 64 bit registers, or 8 bytes, we want a qword of data, which is 8 bytes.
+                            ; Since x86-64 is 64 bit registers, or 8 bytes, we want a qword of data, which is 8 bytes.
     mov     rdx, msg.len    ; rdx holds the number of bytes to write. msg.len is the length of msg
     syscall                 ; invoke operating system to do the write
 

--- a/code/x86-intel/hello-world/hello-world-mac.asm
+++ b/code/x86-intel/hello-world/hello-world-mac.asm
@@ -56,7 +56,7 @@ section .text
 _main:
     mov     rax, 0x2000004  ; system call for write. anything with 0x2 is mac specific
     mov     rdi, 1          ; Set output to stdout. 1 = stdout, which is normally connected to the terminal.
-    mov     rsi, msg        ; address of string to output
+    mov     rsi, qword msg  ; address of string to output
     mov     rdx, msg.len    ; rdx holds the number of bytes to write. msg.len is the length of msg
     syscall                 ; invoke operating system to do the write
 

--- a/code/x86-intel/hello-world/hello-world-mac.asm
+++ b/code/x86-intel/hello-world/hello-world-mac.asm
@@ -56,7 +56,8 @@ section .text
 _main:
     mov     rax, 0x2000004  ; system call for write. anything with 0x2 is mac specific
     mov     rdi, 1          ; Set output to stdout. 1 = stdout, which is normally connected to the terminal.
-    mov     rsi, qword msg  ; address of string to output
+    mov     rsi, qword msg  ; Save the value of msg into rsi. qword is specifying how much data we want to retrieve.
+                                           ; Since x86-64 is 64 bit registers, or 8 bytes, we want a qword of data, which is 8 bytes.
     mov     rdx, msg.len    ; rdx holds the number of bytes to write. msg.len is the length of msg
     syscall                 ; invoke operating system to do the write
 


### PR DESCRIPTION
Original yasm error:

```
> yasm -f macho64 hello-world-mac.asm
hello-world-mac.asm:59: error: macho: sorry, cannot apply 32 bit absolute relocations in 64 bit mode, consider "[_symbol wrt rip]" for mem access, "qword" and "dq _foo" for pointers.
```