### PR TITLE
Fix comment semantics

### DIFF
--- a/guide/writing-code/uppercaser.md
+++ b/guide/writing-code/uppercaser.md
@@ -218,7 +218,7 @@ _main:
   ; ("./uppercaser-mac.asm")
   mov rbx, qword [rcx + 8]
 
-  ; Push the memory address of our command-line arg onto the stack twice.
+  ; Push the value of our command-line arg onto the stack twice.
   ; The first one is to keep the value safe, because we need it after our function call.
   ; The second one is to pass it as an argument to .strLen.
   push rbx

--- a/guide/writing-code/uppercaser.md
+++ b/guide/writing-code/uppercaser.md
@@ -218,7 +218,7 @@ _main:
   ; ("./uppercaser-mac.asm")
   mov rbx, qword [rcx + 8]
 
-  ; Push the value of our command-line arg onto the stack twice.
+  ; Push the value of our command-line arg onto the stack twice.  Argv[][] is an array of arrays, so in this case, the value happens to be another memory address.  The memory address points to the first character of whichever command-line argument we are printing.
   ; The first one is to keep the value safe, because we need it after our function call.
   ; The second one is to pass it as an argument to .strLen.
   push rbx

--- a/guide/writing-code/uppercaser.md
+++ b/guide/writing-code/uppercaser.md
@@ -218,7 +218,10 @@ _main:
   ; ("./uppercaser-mac.asm")
   mov rbx, qword [rcx + 8]
 
-  ; Push the value of our command-line arg onto the stack twice.  Argv[][] is an array of arrays, so in this case, the value happens to be another memory address.  The memory address points to the first character of whichever command-line argument we are printing.
+  ; Push the value of our command-line arg onto the stack twice.
+  ; argv[][] is an array of arrays, so in this case, the value happens
+  ; to be another memory address.  The memory address points to
+  ; the first character of whichever command-line argument we are printing.
   ; The first one is to keep the value safe, because we need it after our function call.
   ; The second one is to pass it as an argument to .strLen.
   push rbx


### PR DESCRIPTION
I think the comment is wrong.  On [L97](https://github.com/hackclub/some-assembly-required/blob/main/guide/writing-code/uppercaser.md?plain=1#L197) it's explained that when using `[]` notation, the value at that location will be returned, not the memory address. 