### PR TITLE
Fix broken links to references that didn't exist

### DIFF
--- a/code/6502/README.md
+++ b/code/6502/README.md
@@ -27,9 +27,9 @@ The 6502 processor has 6 [registers](/guide/cpu/instruction-cycle.md#fetch), thr
 
 We also have access to memory, or [RAM](/guide/cpu/instruction-cycle.md#fetch). Memory addresses are 16 bits long. But, as we mentioned previously, the 6502 processor is an 8-bit processor. Uh oh! What can we do?
 
-Well first, when talking about register data, we must remember that computers only understand numbers, usually represented by [binary digits](/guide/math/number-systems.md#binary). When writing assembly language, we can also use [hex numbers](/guide/math/number-systems.md#hexadecimal), which can be a little easier to read.
+Well first, when talking about register data, we must remember that computers only understand numbers, usually represented by [binary digits](/guide/math/number-systems.md#binary-base-2). When writing assembly language, we can also use [hex numbers](/guide/math/number-systems.md#hexadecimal), which can be a little easier to read.
 
-This is important because later when you look at code examples, you'll see that data is written with only 2 digit [hex numbers](/guide/math/number-systems.md#hexadecimal) like `$02`.
+This is important because later when you look at code examples, you'll see that data is written with only 2 digit [hex numbers](/guide/math/number-systems.md##hexadecimal-base-16) like `$02`.
 
 So, if we want to store anything above 8 bits in a register or in memory, we need to use multiple locations. For example, memory addresses are 16-bits long. If we want to store a memory address, we would store it in two consecutive memory locations (eg. `$0102` and `$0103`). That being said, the program counter is an exception, as it can store 16-bit numbers.
 

--- a/code/6502/README.md
+++ b/code/6502/README.md
@@ -29,7 +29,7 @@ We also have access to memory, or [RAM](/guide/cpu/instruction-cycle.md#fetch). 
 
 Well first, when talking about register data, we must remember that computers only understand numbers, usually represented by [binary digits](/guide/math/number-systems.md#binary-base-2). When writing assembly language, we can also use [hex numbers](/guide/math/number-systems.md#hexadecimal), which can be a little easier to read.
 
-This is important because later when you look at code examples, you'll see that data is written with only 2 digit [hex numbers](/guide/math/number-systems.md##hexadecimal-base-16) like `$02`.
+This is important because later when you look at code examples, you'll see that data is written with only 2 digit [hex numbers](/guide/math/number-systems.md#hexadecimal-base-16) like `$02`.
 
 So, if we want to store anything above 8 bits in a register or in memory, we need to use multiple locations. For example, memory addresses are 16-bits long. If we want to store a memory address, we would store it in two consecutive memory locations (eg. `$0102` and `$0103`). That being said, the program counter is an exception, as it can store 16-bit numbers.
 

--- a/guide/cpu/map.md
+++ b/guide/cpu/map.md
@@ -16,7 +16,7 @@ Remember our registers, or cubbies? We will talk about them [more later](/guide/
 add r12, 4 ; Add the number 4 to the number saved in register 12
 ```
 
-First, the CPU goes and fetches the instruction. In machine code, this could end up looking like this (we will cover what [binary](#binary) is later):
+First, the CPU goes and fetches the instruction. In machine code, this could end up looking like this (we will cover what [binary](/guide/math/number-systems.md#binary-base-2) is later):
 
 ```
 00000001 00001100 00000100

--- a/guide/cpu/physical-world.md
+++ b/guide/cpu/physical-world.md
@@ -1,6 +1,6 @@
 # Electricity and the physical world
 
-Now we know how the CPU is able to interpret machine code, which is just numbers as instructions. And we know that these instructions can be represented with just 1s and 0s, also known as [binary](#binary).
+Now we know how the CPU is able to interpret machine code, which is just numbers as instructions. And we know that these instructions can be represented with just 1s and 0s, also known as [binary](/guide/math/number-systems.md#binary-base-2).
 
 In the physical world, these binary numbers map to electrical circuits. To simplify a bit, if a circuit contains electrical current, it can be considered "on", or **1**. If it doesn't have electrical current, it can be considered "off", or **0**. Using this principle, multiple circuits can be arranged in a group to represent binary numbers.
 


### PR DESCRIPTION
I found some links to references that either didn't exist or don't exist anymore, a couple pointing to a binary reference that didn't work, and one to a hexadecimal reference that didn't work. I found both of these in the `/math/number-systems.md` file and updated the references to match their titles on that file accordingly.