### PR TITLE
fix: fix function call in uppercaser.c

### DIFF
--- a/code/c/uppercaser/uppercaser.c
+++ b/code/c/uppercaser/uppercaser.c
@@ -17,7 +17,7 @@ void print_argument(char *arg);
 
 int main(int argc, char **argv) {
   // Uncomment this to print out number of arguments
-  // printNumberOfArgs(argc);
+  // print_number_of_args(argc);
 
   // Our first argument is the path used to run the program
   // In this case, that's ./uppercaser


### PR DESCRIPTION
The called function before didn't exist, which made **print_number_of_args** useless